### PR TITLE
batファイルのミスを修正しました

### DIFF
--- a/cmake_vs2017_64.bat
+++ b/cmake_vs2017_64.bat
@@ -7,5 +7,5 @@ set BUILD_DIR="build_vs2017_64"
 
 if not exist %BUILD_DIR% mkdir %BUILD_DIR%
 pushd %BUILD_DIR%
-%CMAKE% -D CMAKE_INSTALL_PREFIX=d:/vcpkg/installed/x64-windows -G "Visual Studio 15 2017 Win64" .. 
+%CMAKE% -D CMAKE_INSTALL_PREFIX=%VCPKG_DIR%/installed/x64-windows -G "Visual Studio 15 2017 Win64" .. 
 popd

--- a/cmake_vs2017_64_alembic-1.7.1.bat
+++ b/cmake_vs2017_64_alembic-1.7.1.bat
@@ -8,10 +8,10 @@ set BUILD_DIR="build_vs2017_64_alembic"
 
 if not exist %BUILD_DIR% mkdir %BUILD_DIR%
 pushd %BUILD_DIR%
-%CMAKE% -D CMAKE_INSTALL_PREFIX=%VCPKG_DIR%/installed/x64-windows -D USE_HDF5=ON -D USE_STATIC_HDF5=ON -D HDF5_ROOT=%VCPKG_DIR%/installed/x64-windows/share/hdf5 -D ALEMBIC_DIR=%VCPKG_DIR%/installed/x64-windows/lib/cmake/Alembic -G "Visual Studio 15 2017 Win64" ../alembic-1.7.1 
+%CMAKE% -D CMAKE_INSTALL_PREFIX=%VCPKG_DIR%/installed/x64-windows -D USE_HDF5=ON -D HDF5_ROOT=%VCPKG_DIR%/installed/x64-windows -G "Visual Studio 15 2017 Win64" ../alembic-1.7.1 
 
-%MSBUILD% /p:Configuration=Release /t:Build INSTALL.vcxproj
-%MSBUILD% /p:Configuration=Debug /t:Build INSTALL.vcxproj
+%MSBUILD% /p:Configuration=Release /t:Build /m INSTALL.vcxproj
+%MSBUILD% /p:Configuration=Debug /t:Build /m INSTALL.vcxproj
 
 popd
 

--- a/how_to_build.md
+++ b/how_to_build.md
@@ -106,5 +106,5 @@ mmdbridge
 ``cmake_vs2017_64.bat``を実行して生成された``build_vs2017_64/mmdbridge.sln``をビルドしてください。``INSTALL``をビルドすると実行に必要なdllとpyをMikuMikuDance_x64にコピーします。
 
 ## mmdbridgeのデバッグ実行
-INSTALLプロジェクトのプロパティ - Debug - Targetに``MikuMikuDance_x64/MikuMikuDance.exe``を指定して``F5``実行するとデバッガをアタッチできます。デバッグビルドには、``/Z7``コンパイルオプションでpdbを埋め込んであります。
+INSTALLプロジェクトのプロパティ - デバッグ - コマンド - 参照で``MikuMikuDance_x64/MikuMikuDance.exe``を指定して``F5``実行するとデバッガをアタッチできます。デバッグビルドには、``/Z7``コンパイルオプションでpdbを埋め込んであります。
 


### PR DESCRIPTION
クリーンな環境で問題が再現するのを確認し、修正しました。

cmake_vs2015_64_alembic-1.7.1.bat
Alembicのビルドに失敗する原因のHDF5_ROOTを修正しました。
他、不要・間違っているオプションを削除しました。

cmake_vs2017_64.bat
vcpkgのインストールディレクトリのハードコーディングが残っているのを修正しました。

how_to_build.md
デバッグのくだりの項目名が間違っているのを修正しました。

以上です。
今度は大丈夫なはず。