### PR TITLE
fix avoid unnecessary debug build

### DIFF
--- a/cmake_vs2017_64_alembic-1.7.1.bat
+++ b/cmake_vs2017_64_alembic-1.7.1.bat
@@ -11,7 +11,7 @@ pushd %BUILD_DIR%
 %CMAKE% -D CMAKE_INSTALL_PREFIX=%VCPKG_DIR%/installed/x64-windows -D USE_HDF5=ON -D HDF5_ROOT=%VCPKG_DIR%/installed/x64-windows -G "Visual Studio 15 2017 Win64" ../alembic-1.7.1 
 
 %MSBUILD% /p:Configuration=Release /t:Build /m INSTALL.vcxproj
-%MSBUILD% /p:Configuration=Debug /t:Build /m INSTALL.vcxproj
+%rem %MSBUILD% /p:Configuration=Debug /t:Build /m INSTALL.vcxproj
 
 popd
 


### PR DESCRIPTION
Alembicのdebug版ビルドは不要でした。Alembic.dll(debug版)で上書きしてhdf5_D.dllにリンクしていてよろしくなかったです。